### PR TITLE
GoldenCookieのクリック間隔を正しく変更できるようにする

### DIFF
--- a/main.js
+++ b/main.js
@@ -390,7 +390,7 @@ CookieAssistant.launch = function()
 		//黄金クッキークリック
 		str +=  '<div class="listing">' + m.ToggleButton(CookieAssistant.config.flags, 'autoClickGoldenCookie', 'CookieAssistant_autoClickGoldenCookieButton', 'AutoClick GoldenCookie ON', 'AutoClick GoldenCookie OFF', "CookieAssistant.Toggle")
 				+ '<label>Interval(ms) : </label>'
-				+ m.InputBox("CookieAssistant_Interval_autoClickBigCookie", 40, CookieAssistant.config.intervals.autoClickBigCookie, "CookieAssistant.ChangeInterval('autoClickBigCookie', this.value)")
+				+ m.InputBox("CookieAssistant_Interval_autoClickBigCookie", 40, CookieAssistant.config.intervals.autoClickGoldenCookie, "CookieAssistant.ChangeInterval('autoClickGoldenCookie', this.value)")
 				+ '</div>';
 		//トナカクリック
 		str +=  '<div class="listing">' + m.ToggleButton(CookieAssistant.config.flags, 'autoClickReindeer', 'CookieAssistant_autoClickReindeerButton', 'AutoClick Reindeer(トナカイ) ON', 'AutoClick Reindeer(トナカイ) OFF', "CookieAssistant.Toggle")


### PR DESCRIPTION
GoldenCookieのクリック間隔はBigCookieとは別に[設定されている](https://github.com/hinaloe/CookieAssistant/blob/efbac2b4541634fdbbe873934f448b5e5ee22b5f/main.js#L95-L95)はずであるが、設定のIntervalフィールドがBigCookieのものになってしまっていたのを修正する。