### PR TITLE
ゴールデンクッキー/トナカイが1度の処理ですべてクリックされない問題を修正

### DIFF
--- a/main.js
+++ b/main.js
@@ -383,17 +383,10 @@ CookieAssistant.launch = function()
 				CookieAssistant.intervalHandles.autoClickGoldenCookie = setInterval(
 					() =>
 					{
-						for (var i in Game.shimmers)
-						{
-							if(Game.shimmers[i].type == "golden")
-							{
-								if (CookieAssistant.config.particular.golden.mode == 1 && Game.shimmers[i].wrath != 0)
-								{
-									continue;
-								}
-								Game.shimmers[i].pop();
-							}
-						}
+						Game.shimmers
+							.filter(shimmer => shimmer.type == "golden")
+							.filter(shimmer => !(CookieAssistant.config.particular.golden.mode == 1 &&shimmer.wrath != 0))
+							.forEach(shimmer => shimmer.pop())
 					},
 					CookieAssistant.config.intervals.autoClickGoldenCookie
 				)
@@ -403,13 +396,9 @@ CookieAssistant.launch = function()
 				CookieAssistant.intervalHandles.autoClickReindeer = setInterval(
 					() =>
 					{
-						for (var i in Game.shimmers)
-						{
-							if(Game.shimmers[i].type == "reindeer")
-							{
-								Game.shimmers[i].pop();
-							}
-						}
+						Game.shimmers
+							.filter(shimmer => shimmer.type == "reindeer")
+							.forEach(shimmer => shimmer.pop())
 					},
 					CookieAssistant.config.intervals.autoClickReindeer
 				)


### PR DESCRIPTION
ゴールデンクッキー/トナカイのループ処理内で`pop()`が呼ばれる度に`Game.shimmers`の要素が減って順序がずれる為、
全ての要素に対して処理出来ていない(約半分しか処理されてない)問題を修正しました。
