### PR TITLE
Add CCSE Dependency

### DIFF
--- a/info.txt
+++ b/info.txt
@@ -6,7 +6,7 @@
 	"ModVersion": 0.7,
 	"GameVersion": 2.04,
 	"Date": "08/09/2021",
-	"Dependencies": [],
+	"Dependencies": ["CCSE"],
 	"Disabled": 1,
 	"AllowSteamAchievs": 1
 }


### PR DESCRIPTION
Added CCSE Dependency into info.txt so that the game knows that CCSE is required.
It will show an error if the user hasn't added the CCSE mod themselves.
So it's up to you to decide whether to merge it.
As CookieAssistant installs it automatically this change might break some installations where people rely on the automatic install.